### PR TITLE
Use public RoboRunner SDK

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 .gradle/
 .idea/
+.vscode/
 /build
 /buildSrc/build/
 /gradle/

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This package contains sample code for AWS IoT RoboRunner Fleet Management System
 
 - [Java 17 runtime environment (SE JRE)](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
 - [Gradle 7.3+](https://gradle.org/releases/) (the below versions won't support integration test framework)
-- [Maven 3](https://maven.apache.org/docs/history.html)
 - The Bash shell. For Linux and macOS, this is included by default. In Windows 10, you can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to get a Windows-integrated version of Ubuntu and Bash.
 - [The AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) version 2.
 
@@ -16,22 +15,6 @@ This package contains sample code for AWS IoT RoboRunner Fleet Management System
 
 ```bash
 cli_binary_format=raw-in-base64-out
-```
-
-3. Download the AWS IoT RoboRunner SDK.
-
-```bash
-wget https://d2nqzfmshi5dyg.cloudfront.net/awsiotroborunner_java_sdk-3-0-0.zip
-```
-
-Unzip the SDK zip archive and install it in the local Maven repository.
-
-```bash
-unzip awsiotroborunner_java_sdk-3-0-0.zip
-
-cd awsiotroborunner_java_sdk-3-0-0
-
-mvn install:install-file -Dfile=aws-java-sdk-iotroborunner-3.0.0-SNAPSHOT.jar -DgroupId=com.amazonaws -DartifactId=aws-java-sdk-iotroborunner -Dversion=3.0.0-SNAPSHOT -Dpackaging=jar
 ```
 
 ## Configure

--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,6 @@ repositories {
         url "https://repo.osgeo.org/repository/release/"
     }
   mavenCentral()
-  mavenLocal()
 }
 
 /*
@@ -69,7 +68,7 @@ tasks.named('wrapper') {
 dependencies {
   implementation platform('com.amazonaws:aws-java-sdk-bom:1.12.+')
   implementation 'com.amazonaws:aws-java-sdk-secretsmanager:1.12.+'
-  implementation 'com.amazonaws:aws-java-sdk-iotroborunner:3.0.+'
+  implementation 'com.amazonaws:aws-java-sdk-iotroborunner:1.12.+'
   implementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.+'
 
   implementation 'com.fasterxml.jackson.core:jackson-core:2.12.+'
@@ -130,7 +129,7 @@ testing {
         // By default, only the built-in test suite will automatically have a dependency on the src code.
         implementation project
         implementation 'com.amazonaws:aws-java-sdk-secretsmanager:1.12.+'
-        implementation 'com.amazonaws:aws-java-sdk-iotroborunner:3.0.+'
+        implementation 'com.amazonaws:aws-java-sdk-iotroborunner:1.12.+'
         implementation 'org.apache.commons:commons-lang3:3.+'
         implementation 'org.locationtech.jts:jts-core:1.19.+'
 


### PR DESCRIPTION
Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>

*Description of changes:*
* Use public RoboRunner SDK
* Update README to remove Maven installation and private SDK installation instructions
* Update RoboRunner SDK dependency version to match public SDK version

*Testing:*
`gradle clean build` succeeds

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
