### PR TITLE
Upgrade Gradle version to v7.6

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: 'Setup Gradle'
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.5.1
+          gradle-version: 7.6
 
       - name: 'Execute Gradle build'
         run: gradle clean build

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package contains sample code for AWS IoT RoboRunner Fleet Management System
 Install the required dependencies:
 
 - [Java 17 runtime environment (SE JRE)](https://www.oracle.com/java/technologies/javase/jdk17-archive-downloads.html)
-- [Gradle v7.5.1](https://gradle.org/releases/)
+- [Gradle v7.6](https://gradle.org/releases/)
 
 ## Configure
 

--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,7 @@ repositories {
  See more: https://docs.gradle.org/current/userguide/gradle_wrapper.html
 */
 tasks.named('wrapper') {
-  gradleVersion = '7.5.1';
+  gradleVersion = '7.6';
   distributionType = Wrapper.DistributionType.ALL
 }
 
@@ -127,7 +127,7 @@ testing {
       dependencies {
         // Adds a dependency on the src code of the application to the integrationTest suite targets.
         // By default, only the built-in test suite will automatically have a dependency on the src code.
-        implementation project
+        implementation project()
         implementation 'com.amazonaws:aws-java-sdk-secretsmanager:1.12.+'
         implementation 'com.amazonaws:aws-java-sdk-iotroborunner:1.12.+'
         implementation 'org.apache.commons:commons-lang3:3.+'


### PR DESCRIPTION
*Problem*

- Gradle released a new version (v7.6). To keep FMSG up-to-date, an upgrade is needed
- Test suite cannot be built with Gradle v7.6 as there are syntax differences between current version (v7.5.1) and v7.6

**Solution**

- Upgrade Gradle version from v7.5.1 to v7.6 within `gradle wrapper` task definition
- Adjust README instructions to reflect version upgrade
- Update the GitHub Action Gradle version from v7.5.1 to v7.6

**Testing**

- ./gradlew clean build: `PASS` (including unit tests)
- Deploy FMSG to AWS account as described in https://docs.aws.amazon.com/iotroborunner/latest/dev/iotroborunner-fmsg.html `successfully`. Logs are as expected.
- ./gradlew clean integrationTest: `PASS`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
