### PR TITLE
Add check for KMS alias existence

### DIFF
--- a/src/com/amazon/iotroborunner/fmsg/clients/AwsKmsClientProvider.java
+++ b/src/com/amazon/iotroborunner/fmsg/clients/AwsKmsClientProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.iotroborunner.fmsg.clients;
+
+import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.AWSKMSClientBuilder;
+import lombok.NonNull;
+
+/**
+ * A final class that contains the method to create an Amazon KMS client.
+ */
+public final class AwsKmsClientProvider {
+    /**
+     * Builds and returns an Amazon KMS client.
+     *
+     * @return Amazon KMS client
+     */
+    public AWSKMS getAmazonKmsClient(@NonNull final String region) {
+        return AWSKMSClientBuilder.standard().withRegion(region).build();
+    }
+}

--- a/tst/com/amazon/iotroborunner/fmsg/sharedspacemgmt/FmsgSharedSpaceMgmtTest.java
+++ b/tst/com/amazon/iotroborunner/fmsg/sharedspacemgmt/FmsgSharedSpaceMgmtTest.java
@@ -61,6 +61,7 @@ import com.amazonaws.services.iotroborunner.model.Destination;
 import com.amazonaws.services.iotroborunner.model.DestinationState;
 import com.amazonaws.services.iotroborunner.model.ListDestinationsRequest;
 import com.amazonaws.services.iotroborunner.model.ListDestinationsResult;
+import com.amazonaws.services.kms.AWSKMS;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.logging.log4j.Level;
@@ -92,6 +93,8 @@ public class FmsgSharedSpaceMgmtTest {
     private SharedSpaceManagementPriorityQueue priorityQueue;
     @Mock
     private AmazonDynamoDB dynamoDbClient;
+    @Mock
+    private AWSKMS mockKmsClient;
 
     private FmsgSharedSpaceMgmt classUnderTest;
 
@@ -129,7 +132,7 @@ public class FmsgSharedSpaceMgmtTest {
     @BeforeEach
     public void initializeTestClass() {
         classUnderTest = new FmsgSharedSpaceMgmt(configs, this.executorService, roboRunnerClient, dynamoDbClient,
-            priorityQueue, connectorsByWorkerFleet);
+            mockKmsClient, priorityQueue, connectorsByWorkerFleet);
     }
 
     /**


### PR DESCRIPTION
**Problem**

AWS IoT RoboRunner offers the ability to automatically create a shared space management priority queue if it doesn’t already exist in the AWS account and there is a dedicated customer managed AWS KMS key to use. By providing explicit verbage and checking for the required AWS KMS key, we now make it easier to understand if the key is missing.

**Solution**

We've implemented an explicit test for the sm-priority-queue-cmk customer managed AWS KMS key at the start of operations. If the key isn't found, a clear message will be logged to help isolate the problem quickly.

**Testing**

Previous unit tests within PriorityQueueUtils have been updated to reflect the changes made.

./gradlew clean build passes