### PR TITLE
Add a utility to build a JSON for metric data

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,9 +70,12 @@ dependencies {
   implementation 'com.amazonaws:aws-java-sdk-secretsmanager:1.12.+'
   implementation 'com.amazonaws:aws-java-sdk-iotroborunner:1.12.+'
   implementation 'com.amazonaws:aws-java-sdk-dynamodb:1.12.+'
+  implementation 'com.amazonaws:aws-java-sdk-cloudwatch:1.12.+'
 
   implementation 'com.fasterxml.jackson.core:jackson-core:2.12.+'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.+'
+
+  implementation 'org.json:json:20220924'
 
   implementation 'org.boofcv:boofcv-core:0.40.+'
 

--- a/src/com/amazon/iotroborunner/fmsg/constants/CloudWatchConstants.java
+++ b/src/com/amazon/iotroborunner/fmsg/constants/CloudWatchConstants.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.iotroborunner.fmsg.constants;
+
+/**
+ * Constants to be used when working with CloudWatch or CloudWatch data.
+ */
+public class CloudWatchConstants {
+    /**
+     * The key used for publishing a metric.
+     */
+    public static final String METRIC_REQUEST_KEY = "request";
+
+    /**
+     * The key used for the namespace of a metric.
+     */
+    public static final String METRIC_NAMESPACE_KEY = "namespace";
+
+    /**
+     * The key used for the data of a metric.
+     */
+    public static final String METRIC_CONTENT_KEY = "metricData";
+
+    /**
+     * The key used for the name of a metric.
+     */
+    public static final String METRIC_NAME_KEY = "MetricName";
+
+    /**
+     * The key used for the dimensions of a metric.
+     */
+    public static final String METRIC_DIMENSIONS_KEY = "Dimensions";
+
+    /**
+     * The key used for the unit of a metric.
+     */
+    public static final String METRIC_UNIT_KEY = "Unit";
+
+    /**
+     * The key used for the value of a metric.
+     */
+    public static final String METRIC_VALUE_KEY = "Value";
+
+    /**
+     * The key used for the timestamp of a metric.
+     */
+    public static final String METRIC_TIMESTAMP_KEY = "Timestamp";
+
+    /**
+     * The key used for the name of the dimension in a metric.
+     */
+    public static final String METRIC_DIMENSION_NAME_KEY = "Name";
+
+    /**
+     * The key used for the value of the dimension in a metric.
+     */
+    public static final String METRIC_DIMENSION_VALUE_KEY = "Value";
+
+    /**
+     * Hidden constructor.
+     */
+    private CloudWatchConstants() {
+        throw new UnsupportedOperationException("This class is for holding constants and should not be instantiated.");
+    }
+}

--- a/src/com/amazon/iotroborunner/fmsg/utils/CloudWatchUtils.java
+++ b/src/com/amazon/iotroborunner/fmsg/utils/CloudWatchUtils.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.iotroborunner.fmsg.utils;
+
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_CONTENT_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_DIMENSIONS_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_DIMENSION_NAME_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_DIMENSION_VALUE_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_NAMESPACE_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_NAME_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_REQUEST_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_TIMESTAMP_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_UNIT_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_VALUE_KEY;
+
+import java.time.Instant;
+import java.util.List;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.amazonaws.util.CollectionUtils;
+import lombok.NonNull;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+/**
+ * Utilities designed to be used in regard to CloudWatch and related operations.
+ */
+public class CloudWatchUtils {
+
+    /**
+     * Constructs a JSON string representing metric data.
+     *
+     * @param namespace the required namespace of the metric
+     * @param metricName the required name of the metric
+     * @param dimensions the dimensions of the metric
+     * @param unit the required unit of the metric
+     * @param value the required value of the metric
+     * @return the string representing the metric json
+     */
+    public static String constructMetricJsonString(@NonNull final String namespace,
+                                               @NonNull final String metricName,
+                                               final List<Dimension> dimensions,
+                                               @NonNull final StandardUnit unit,
+                                               final double value) {
+        final JSONObject metricData = new JSONObject() {{
+                put(METRIC_NAME_KEY, metricName);
+                put(METRIC_UNIT_KEY, unit);
+                put(METRIC_VALUE_KEY, value);
+                put(METRIC_TIMESTAMP_KEY, Instant.now());
+            }};
+
+        if (!CollectionUtils.isNullOrEmpty(dimensions)) {
+            final JSONArray dimensionsArr = new JSONArray();
+
+            // Add the dimensions one by one instead of providing the collection
+            // as a param to avoid any changes to the property formatting.
+            for (final Dimension dimension : dimensions) {
+                final JSONObject dimensionObj = new JSONObject();
+                dimensionObj.put(METRIC_DIMENSION_NAME_KEY, dimension.getName());
+                dimensionObj.put(METRIC_DIMENSION_VALUE_KEY, dimension.getValue());
+                dimensionsArr.put(dimensionObj);
+            }
+            metricData.put(METRIC_DIMENSIONS_KEY, dimensionsArr);
+        }
+
+        final JSONObject metricObj = new JSONObject() {{
+                put(METRIC_NAMESPACE_KEY, namespace);
+                put(METRIC_CONTENT_KEY, metricData);
+            }};
+
+        final JSONObject request = new JSONObject() {{
+                put(METRIC_REQUEST_KEY, metricObj);
+            }};
+
+        return request.toString();
+    }
+
+    /**
+     * Hidden constructor.
+     */
+    private CloudWatchUtils() {
+        throw new UnsupportedOperationException("This class is for holding utilities and should not be instantiated.");
+    }
+}

--- a/tst/com/amazon/iotroborunner/fmsg/utils/CloudWatchUtilsTest.java
+++ b/tst/com/amazon/iotroborunner/fmsg/utils/CloudWatchUtilsTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.iotroborunner.fmsg.utils;
+
+
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_CONTENT_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_DIMENSIONS_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_DIMENSION_NAME_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_DIMENSION_VALUE_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_NAMESPACE_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_NAME_KEY;
+import static com.amazon.iotroborunner.fmsg.constants.CloudWatchConstants.METRIC_REQUEST_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for the CloudWatch utility module.
+ */
+@ExtendWith(MockitoExtension.class)
+public class CloudWatchUtilsTest {
+    @Test
+    void given_allValidParams_when_constructMetricJsonString_then_returnsValidMetricJsonString() throws JsonProcessingException {
+        final String namespace = "FleetManagementSystemGateway";
+        final String metricName = "SecretRetrievalFailed";
+        final String dimensionName = "secretName";
+        final String dimensionValue = "testSecret";
+        final List<Dimension> dimensions = new ArrayList<>() {{
+                add(new Dimension()
+                    .withName(dimensionName)
+                    .withValue(dimensionValue));
+            }};
+        final String metricRequestString = CloudWatchUtils.constructMetricJsonString(
+                namespace, metricName, dimensions, StandardUnit.Count, 1);
+
+        final JSONObject metricRequestJsonObj = new JSONObject(metricRequestString).getJSONObject(METRIC_REQUEST_KEY);
+        final JSONObject metricDataJsonObj = metricRequestJsonObj.getJSONObject(METRIC_CONTENT_KEY);
+        final JSONArray metricDimensionsJsonArr = metricDataJsonObj.getJSONArray(METRIC_DIMENSIONS_KEY);
+        assertEquals(namespace, metricRequestJsonObj.getString(METRIC_NAMESPACE_KEY));
+        assertEquals(metricName, metricDataJsonObj.getString(METRIC_NAME_KEY));
+        assertEquals(1, metricDimensionsJsonArr.length());
+        final JSONObject dimensionJsonObj = metricDimensionsJsonArr.getJSONObject(0);
+        assertEquals(dimensionName, dimensionJsonObj.getString(METRIC_DIMENSION_NAME_KEY));
+        assertEquals(dimensionValue, dimensionJsonObj.getString(METRIC_DIMENSION_VALUE_KEY));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @Disabled
+    void given_allValidParamsWithNoDimensions_when_constructMetricJsonString_then_jsonStringDoesNotContainDimensions(
+            final List<Dimension> dimensions) {
+        final String metricRequestString = CloudWatchUtils.constructMetricJsonString(
+                "FleetManagementSystemGateway", "SecretRetrievalFailed", dimensions, StandardUnit.Count, 1);
+
+        final JSONObject metricRequestJsonObj = new JSONObject(metricRequestString).getJSONObject(METRIC_REQUEST_KEY);
+        final JSONObject metricDataJsonObj = metricRequestJsonObj.getJSONObject(METRIC_CONTENT_KEY);
+        assertFalse(metricDataJsonObj.has(METRIC_DIMENSIONS_KEY));
+    }
+}


### PR DESCRIPTION
**Problem**

Variety of metrics will be emitted to Cloudwatch from the FMSG. These metrics must be formatted as a JSON string so that they can be processed by the Lambda function that publishes the metrics to Cloudwatch. We will need a utility that allows the creation of the data for each of these metrics easily without redundancy.

**Solution**

Create a utility method that will provide the functionality to create the metric data.

**Testing**

- ./gradlew clean build: `PASS` (includes all unit tests) 
- ./gradlew clean test --tests - -com.amazon.iotroborunner.fmsg.utils.CloudWatchUtilsTest: `PASS`
-  Manually create a simple lambda and pass the output of this
method to lambda to see if it will publish to CloudWatch correctly: `PASS`.
